### PR TITLE
Fix path_to_module to handle hidden files (e.g. .clang-tidy) correctly

### DIFF
--- a/src/scikit_build_core/build/_pathutil.py
+++ b/src/scikit_build_core/build/_pathutil.py
@@ -28,7 +28,7 @@ def scantree(path: Path) -> Generator[Path, None, None]:
 
 
 def path_to_module(path: Path) -> str:
-    path = path.with_name(path.name.split(".", 1)[0])
+    path = path.with_name(path.stem)
     if path.name == "__init__":
         path = path.parent
     return ".".join(path.parts)


### PR DESCRIPTION
I got the error below without this fix because it can't handle hidden file's extension corretly:
```
    File "/opt/miniconda3/envs/pyapl/lib/python3.12/site-packages/scikit_build_core/build/_pathutil.py", line 31, in path_to_module
      path = path.with_name(path.name.split(".", 1)[0])
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/opt/miniconda3/envs/pyapl/lib/python3.12/pathlib.py", line 634, in with_name
      raise ValueError("Invalid name %r" % (name))
  ValueError: Invalid name ''
```
For example, if it's `.clang-tidy`, the original splitting `path.name.split(".", 1)[0]` results empty string.
But `path.stem` can handle hidden files!